### PR TITLE
fix: excluding aws-modules

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -233,7 +233,7 @@ runs:
           IFS=, read -a Array <<<"$unprocessed_list"
           for i in "${Array[@]}"
           do
-            if [[ $i == *".json"* ]] || [[ $i == *"yml"* ]] || [[ $i == *"md"* ]] || [[ $i == *"prettier"* ]] || [[ $i == *".png"* ]] || [[ $i == *"ignore"* ]]; then
+            if [[ $i == *".json"* ]] || [[ $i == *"yml"* ]] || [[ $i == *"md"* ]] || [[ $i == *"prettier"* ]] || [[ $i == *".png"* ]] || [[ $i == *"ignore"* ]] || [[ $i == *"aws-modules"* ]]; then
                 echo "excluding ${i} from diff-file list"
             else
                 processed_list="${i}",${processed_list}


### PR DESCRIPTION
For the following error: 
```
File aws-modules doesn't exist
  Exit Code: 1
```
Error run:
https://github.com/ncino/force-LLC_BI/runs/6471636593?check_suite_focus=true

Tested change on this PR:
https://github.com/ncino/force-LLC_BI/pull/15085